### PR TITLE
fix-bug-forward-delete-notification-via-stream-queue

### DIFF
--- a/upsf_server/server.py
+++ b/upsf_server/server.py
@@ -679,6 +679,7 @@ class SssUpsfServicer(service_v1_pb2_grpc.upsfServicer):
                                 "name": command_dict["name"],
                             }
                         )
+                        rconn.publish("UpdatesEgress", command)
                         continue
 
                     mapping = rconn.hgetall(_redis_key_ingress)


### PR DESCRIPTION
- error description:
  - in static method subscribe_to_queue we suppress events of type  "DeleteV1"
- change:
  - send "DeleteV1" event to redis queue UpdatesEgress to notify listening peers